### PR TITLE
Added PlayerInfoStatus property

### DIFF
--- a/DotnetOsrsApiWrapper/DotnetOsrsApiWrapper.csproj
+++ b/DotnetOsrsApiWrapper/DotnetOsrsApiWrapper.csproj
@@ -6,10 +6,10 @@
     <Company />
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>A simple wrapper for the osrs api.</Description>
-    <Version>2.2.1</Version>
+    <Version>2.3.0</Version>
     <RepositoryUrl>https://github.com/Assasindie/DotnetOsrsApiWrapper</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <AssemblyVersion>2.2.0.0</AssemblyVersion>
+    <AssemblyVersion>2.3.0.0</AssemblyVersion>
     <PackageReleaseNotes>Updated to include bossing highscores. Will break probably display wrong information when next boss/minigame is released</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/DotnetOsrsApiWrapper/PlayerInfo.cs
+++ b/DotnetOsrsApiWrapper/PlayerInfo.cs
@@ -16,6 +16,7 @@ namespace DotnetOsrsApiWrapper
 
         //do not re-order this or it will break it all
         public string Name { get; set; } = "";
+        public PlayerInfoStatus Status { get; internal set; } = PlayerInfoStatus.Unknown;
         public Skill Overall { get; set; } = InitialSkillState;
         public Skill Attack { get; set; } = InitialSkillState;
         public Skill Defence { get; set; } = InitialSkillState;

--- a/DotnetOsrsApiWrapper/PlayerInfoStatus.cs
+++ b/DotnetOsrsApiWrapper/PlayerInfoStatus.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DotnetOsrsApiWrapper
+{
+    public enum PlayerInfoStatus
+    {
+        Unknown,
+        NotFound,
+        Success
+    }
+}


### PR DESCRIPTION
I've added a new Property to PlayerInfo, to indicate whether the service call was successful or not. I've done so as I found if 1 call fails when using the IEnumerable method, the whole batch fails with little feedback to the caller. Now the service will set status to NotFound, so those accounts can be marked as name changed.

This is a fairly rudimentary approach, so if you have any suggestions I'm all ears.